### PR TITLE
Quick README explainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
-# charts
-Public Helm chart packages used for Infratographer deployments
+<p align="center">
+  <img src="https://avatars.githubusercontent.com/u/99778269?s=200&v=4" alt="Infratographer Avatar"/>
+</p>
+
+This is a repository containing the packaged Helm charts for the Infratographer GitHub org. The source for these files can be found [here](https://github.com/infratographer/charts/tree/gh-pages)
+
+## Process
+
+- Charts are published to the `gh-pages` branch of this repository via automation in each of the upstream Infratographer repositories. When a tag is created in any of these repositories a corresponding release will be cut for the Helm chart and published here.


### PR DESCRIPTION
Adds a quick README landing page that mirrors the one found in the `gh-pages` branch (which will act as the source for our Helm repository) and also adds a quick explainer for how charts get published here.